### PR TITLE
Fixes #9

### DIFF
--- a/inst/sql/sql_server/checks/mapping_completeness.sql
+++ b/inst/sql/sql_server/checks/mapping_completeness.sql
@@ -1,7 +1,7 @@
 --Query 2 Completeness of Mappings per Entity
 select 'condition' as domain, count_big(*) as num_source_concepts,
-       sum(case when is_mapped > 0 then 1 else 0 end) as num_mapped_codes,
-       1.0*sum(case when is_mapped > 0 then 1 else 0 end) / count_big(*) as pct_mapped_codes,
+       sum(is_mapped) as num_mapped_codes,
+       1.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
        sum(num_records) as num_records,
        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
        1.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
@@ -15,8 +15,8 @@ group by condition_source_value, case when condition_concept_id > 0 then 1 else 
 union
 
 select 'procedure' as domain, count_big(*) as num_source_concepts,
-       sum(case when is_mapped > 0 then 1 else 0 end) as num_mapped_codes,
-       1.0*sum(case when is_mapped > 0 then 1 else 0 end) / count_big(*) as pct_mapped_codes,
+       sum(is_mapped) as num_mapped_codes,
+       1.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
        sum(num_records) as num_records,
        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
        1.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
@@ -30,8 +30,8 @@ group by procedure_source_value, case when procedure_concept_id > 0 then 1 else 
 union
 
 select 'device' as domain, count_big(*) as num_source_concepts,
-       sum(case when is_mapped > 0 then 1 else 0 end) as num_mapped_codes,
-       1.0*sum(case when is_mapped > 0 then 1 else 0 end) / count_big(*) as pct_mapped_codes,
+       sum(is_mapped) as num_mapped_codes,
+       1.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
        sum(num_records) as num_records,
        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
        1.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
@@ -46,8 +46,8 @@ group by device_source_value, case when device_concept_id > 0 then 1 else 0 end
 union
 
 select 'drug' as domain, count_big(*) as num_source_concepts,
-       sum(case when is_mapped > 0 then 1 else 0 end) as num_mapped_codes,
-       1.0*sum(case when is_mapped > 0 then 1 else 0 end) / count_big(*) as pct_mapped_codes,
+       sum(is_mapped) as num_mapped_codes,
+       1.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
        sum(num_records) as num_records,
        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
        1.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
@@ -63,8 +63,8 @@ group by drug_source_value, case when drug_concept_id > 0 then 1 else 0 end
 union
 
 select 'observation' as domain, count_big(*) as num_source_concepts,
-       sum(case when is_mapped > 0 then 1 else 0 end) as num_mapped_codes,
-       1.0*sum(case when is_mapped > 0 then 1 else 0 end) / count_big(*) as pct_mapped_codes,
+       sum(is_mapped) as num_mapped_codes,
+       1.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
        sum(num_records) as num_records,
        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
        1.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
@@ -80,8 +80,8 @@ group by observation_source_value, case when observation_concept_id > 0 then 1 e
 union
 
 select 'measurement' as domain, count_big(*) as num_source_concepts,
-       sum(case when is_mapped > 0 then 1 else 0 end) as num_mapped_codes,
-       1.0*sum(case when is_mapped > 0 then 1 else 0 end) / count_big(*) as pct_mapped_codes,
+       sum(is_mapped) as num_mapped_codes,
+       1.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
        sum(num_records) as num_records,
        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
        1.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
@@ -95,8 +95,8 @@ group by measurement_source_value, case when measurement_concept_id > 0 then 1 e
 union
 
 select 'visit_occurrence' as domain, count_big(*) as num_source_concepts,
-       sum(case when is_mapped > 0 then 1 else 0 end) as num_mapped_codes,
-       1.0*sum(case when is_mapped > 0 then 1 else 0 end) / count_big(*) as pct_mapped_codes,
+       sum(is_mapped) as num_mapped_codes,
+       1.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
        sum(num_records) as num_records,
        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
        1.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records


### PR DESCRIPTION
By replacing `count(distinct source_value)` by `count(*)`, a nan value will also be counted.
As the query already groups by source_value, the resulting count is the same.