### PR TITLE
Fix for Table 1. Clinical data counts

### DIFF
--- a/R/ResultsDocumentGeneration.R
+++ b/R/ResultsDocumentGeneration.R
@@ -97,10 +97,11 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
 
     ## add Concept counts
   if (!is.null(results$dataTablesResults)) {
+    df_t1 <- results$dataTablesResults$dataTablesCounts$result
     doc<-doc %>%
       officer::body_add_par(value = "Record counts data tables", style = "heading 2") %>%
       officer::body_add_par("Table 1. Shows the number of records in all clinical data tables") %>%
-      my_body_add_table(value = results$dataTablesResults$dataTablesCounts$result, style = "EHDEN") %>%
+      my_body_add_table(value = df_t1[order(df_t1$COUNT, decreasing=TRUE),], style = "EHDEN") %>%
       officer::body_add_par(" ") %>%
       officer::body_add_par(paste("Query executed in ",sprintf("%.2f", results$dataTablesResults$dataTablesCounts$duration),"secs"))
 

--- a/inst/sql/sql_server/checks/data_tables_count.sql
+++ b/inst/sql/sql_server/checks/data_tables_count.sql
@@ -6,9 +6,9 @@ select 'care_site' as tablename, count_big(*) as count from @cdmDatabaseSchema.c
 UNION
 select 'condition_era' as tablename, count_big(*) as count from @cdmDatabaseSchema.condition_era
 UNION
-select 'condition occurrence' as tablename, count_big(*) as count from @cdmDatabaseSchema.condition_occurrence
+select 'condition_occurrence' as tablename, count_big(*) as count from @cdmDatabaseSchema.condition_occurrence
 UNION
-select 'drug exposure' as tablename, count_big(*) as count from @cdmDatabaseSchema.drug_exposure
+select 'drug_exposure' as tablename, count_big(*) as count from @cdmDatabaseSchema.drug_exposure
 UNION
 select 'cost' as tablename, count_big(*) as count from @cdmDatabaseSchema.cost
 UNION
@@ -20,13 +20,9 @@ select 'dose_era' as tablename, count_big(*) as count from @cdmDatabaseSchema.do
 UNION
 select 'drug_era' as tablename, count_big(*) as count from @cdmDatabaseSchema.drug_era
 UNION
-select 'drug_exposure' as tablename, count_big(*) as count from @cdmDatabaseSchema.drug_exposure
-UNION
 select 'location' as tablename, count_big(*) as count from @cdmDatabaseSchema.location
 UNION
 select 'measurement' as tablename, count_big(*) as count from @cdmDatabaseSchema.measurement
-UNION
-select 'device_exposure' as tablename, count_big(*) as count from @cdmDatabaseSchema.device_exposure
 UNION
 select 'note' as tablename, count_big(*) as count from @cdmDatabaseSchema.note
 UNION
@@ -43,3 +39,5 @@ UNION
 select 'specimen' as tablename, count_big(*) as count from @cdmDatabaseSchema.specimen
 UNION
 select 'visit_details' as tablename, count_big(*) as count from @cdmDatabaseSchema.visit_detail
+UNION
+select 'visit_occurrence' as tablename, count_big(*) as count from @cdmDatabaseSchema.visit_occurrence


### PR DESCRIPTION
All clinical tables listed once, with underscore and sorted on count descending.

![image](https://user-images.githubusercontent.com/17825660/103094093-b2df8400-45fc-11eb-9ec0-c6f30472df45.png)
