### PR TITLE
add external packages names before their function(s) in R folder

### DIFF
--- a/R/CdmInspection.R
+++ b/R/CdmInspection.R
@@ -188,7 +188,7 @@ cdmInspection <- function (connectionDetails,
       ParallelLogger::logInfo(paste0("Running WebAPIChecks"))
 
       tryCatch({
-        webAPIversion <- getWebApiVersion(baseUrl = baseUrl)
+        webAPIversion <- ROhdsiWebApi::getWebApiVersion(baseUrl = baseUrl)
         ParallelLogger::logInfo(sprintf("> Connected successfully to %s", baseUrl))
         ParallelLogger::logInfo(sprintf("> WebAPI version: %s", webAPIversion))},
                error = function (e) {

--- a/R/Helper.R
+++ b/R/Helper.R
@@ -68,7 +68,7 @@ my_body_add_table <- function (x, value, style = NULL, pos = "after", header = T
           first_column = FALSE, last_row = FALSE, last_column = FALSE,
           no_hband = FALSE, no_vband = TRUE, align = "left")
 {
-  pt <- prop_table(style = style, layout = table_layout(),
+  pt <- officer::prop_table(style = style, layout = table_layout(),
                    width = table_width(), stylenames = stylenames,
                    tcf = table_conditional_formatting(first_row = first_row,
                                                       first_column = first_column, last_row = last_row,
@@ -88,10 +88,10 @@ my_body_add_table <- function (x, value, style = NULL, pos = "after", header = T
     }
   }
 
-  bt <- block_table(x = value, header = header, properties = pt,
+  bt <- officer::block_table(x = value, header = header, properties = pt,
                     alignment = alignment)
-  xml_elt <- to_wml(bt, add_ns = TRUE, base_document = x)
-  body_add_xml(x = x, str = xml_elt, pos = pos)
+  xml_elt <- officer::to_wml(bt, add_ns = TRUE, base_document = x)
+  officer::body_add_xml(x = x, str = xml_elt, pos = pos)
 }
 
 
@@ -125,9 +125,9 @@ my_mapped_section <- function(x, data, table_number, domain, smallCellCount) {
 
 recordsCountPlot <- function(results){
   temp <- results %>%
-    rename(Date=X_CALENDAR_MONTH,Domain=SERIES_NAME, Count=Y_RECORD_COUNT) %>%
-    mutate(Date=parse_date_time(Date, "ym"))
-  plot <- ggplot(temp, aes(x = Date, y = Count)) + geom_line(aes(color = Domain))
+    dplyr::rename(Date=X_CALENDAR_MONTH,Domain=SERIES_NAME, Count=Y_RECORD_COUNT) %>%
+    dplyr::mutate(Date=lubridate::parse_date_time(Date, "ym"))
+  plot <- ggplot2::ggplot(temp, aes(x = Date, y = Count)) + geom_line(aes(color = Domain))
 }
 
 #' @export

--- a/R/ResultsDocumentGeneration.R
+++ b/R/ResultsDocumentGeneration.R
@@ -17,16 +17,16 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
     officer::body_add_img(logo,width=6.10,height=1.59, style = "Title") %>%
     officer::body_add_par(value = paste0("CDM Inspection report for the ",databaseName," database"), style = "Title") %>%
     #body_add_par(value = "Note", style = "heading 1") %>%
-    body_add_par(value = paste0("Package Version: ", packageVersion("CdmInspection")), style = "Centered") %>%
-    body_add_par(value = paste0("Date: ", date()), style = "Centered") %>%
-    body_add_par(value = paste0("Authors: ", authors), style = "Centered") %>%
-    body_add_break()
+    officer::body_add_par(value = paste0("Package Version: ", packageVersion("CdmInspection")), style = "Centered") %>%
+    officer::body_add_par(value = paste0("Date: ", date()), style = "Centered") %>%
+    officer::body_add_par(value = paste0("Authors: ", authors), style = "Centered") %>%
+    officer::body_add_break()
 
   ## add Table of content
   doc<-doc %>%
     officer::body_add_par(value = "Table of content", style = "heading 1") %>%
     officer::body_add_toc(level = 2) %>%
-    body_add_break()
+    officer::body_add_break()
 
 
   ## add genereal section
@@ -42,12 +42,12 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
                  )
   answers <- c("",databaseName, databaseId,"","","","","")
   preample <- data.frame(items,answers)
-  ft <- qflextable(preample)
-  ft<-set_table_properties(ft, width = 1, layout = "fixed")
-  ft <- bold(ft, bold = TRUE, part = "header")
-  border_v = fp_border(color="gray")
-  border_h = fp_border(color="gray")
-  ft<-border_inner_v(ft, part="all", border = border_v )
+  ft <- flextable::qflextable(preample)
+  ft<-flextable::set_table_properties(ft, width = 1, layout = "fixed")
+  ft <- flextable::bold(ft, bold = TRUE, part = "header")
+  border_v = officer::fp_border(color="gray")
+  border_h = officer::fp_border(color="gray")
+  ft<-flextable::border_inner_v(ft, part="all", border = border_v )
 
   doc<-doc %>%
     officer::body_add_par(value = "General Information", style = "heading 1") %>%
@@ -55,7 +55,7 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
     officer::body_add_par(value = "The goal of the inspection report is to provide insight into the completeness, transparency and quality of the performed Extraction Transform, and Load (ETL) process and the readiness of the data source to be onboarded in the data network to participate in research studies.") %>%
 
     officer::body_add_par(value = "Contact Details", style = "heading 2") %>%
-    body_add_par(value = "Fill in the table below",style="Highlight") %>%
+    officer::body_add_par(value = "Fill in the table below",style="Highlight") %>%
 
     flextable::body_add_flextable(value = ft, align = "left")
   doc<-doc %>%
@@ -71,8 +71,8 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
 
     doc<-doc %>% officer::body_add_par(value = "SME Role", style = "heading 2") %>%
 
-    body_add_par(value = "Describe the involvement of the SME in the ETL Delopment process",style="Highlight") %>%
-    body_add_break()
+    officer::body_add_par(value = "Describe the involvement of the SME in the ETL Delopment process",style="Highlight") %>%
+    officer::body_add_break()
 
 
   ## ETL Development section
@@ -106,18 +106,18 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
       officer::body_add_par(paste("Query executed in ",sprintf("%.2f", results$dataTablesResults$dataTablesCounts$duration),"secs"))
 
     plot <- recordsCountPlot(as.data.frame(results$dataTablesResults$totalRecords$result))
-    doc<-doc %>% body_add_break() %>%
-      body_add_par(value = "Data density plots", style = "heading 2") %>%
-      body_add_gg(plot, height=4) %>%
-      body_add_par("Figure 1. Total record count over time per data domain")
+    doc<-doc %>% officer::body_add_break() %>%
+      officer::body_add_par(value = "Data density plots", style = "heading 2") %>%
+      officer::body_add_gg(plot, height=4) %>%
+      officer::body_add_par("Figure 1. Total record count over time per data domain")
 
     plot <- recordsCountPlot(as.data.frame(results$dataTablesResults$recordsPerPerson$result))
     doc<-doc %>%
-      body_add_gg(plot, height=4) %>%
-      body_add_par("Figure 2. Number of records per person over time per data domain")
+      officer::body_add_gg(plot, height=4) %>%
+      officer::body_add_par("Figure 2. Number of records per person over time per data domain")
 
     colnames(results$dataTablesResults$conceptsPerPerson$result) <- c("Domain", "Min", "P10", "P25", "MEDIAN", "P75", "P90", "Max")
-    doc<-doc %>% body_add_break() %>%
+    doc<-doc %>% officer::body_add_break() %>%
       officer::body_add_par(value = "Concepts per person", style = "heading 2") %>%
       officer::body_add_par("Table 2. Shows the number of records per person for all data domains") %>%
       my_body_add_table(value = results$dataTablesResults$conceptsPerPerson$result, style = "EHDEN") %>%
@@ -164,7 +164,7 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
       my_body_add_table(value = vocabResults$mappingCompleteness$result, style = "EHDEN", alignment = c('l', rep('r',6))) %>%
       officer::body_add_par(" ") %>%
       officer::body_add_par(paste("Query executed in ",sprintf("%.2f", vocabResults$mappingCompleteness$duration),"secs")) %>%
-      body_add_break()
+      officer::body_add_break()
 
     ## add Drug Level Mappings
     doc<-doc %>%
@@ -207,7 +207,7 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
   } else {
     doc<-doc %>%
     officer::body_add_par("Vocabulary checks have not been executed, runVocabularyChecks = FALSE?", style="Highlight") %>%
-    body_add_break()
+    officer::body_add_break()
   }
 
   doc<-doc %>%
@@ -218,7 +218,7 @@ generateResultsDocument<- function(results, outputFolder, docTemplate="EHDEN", a
 
   if (!is.null(results$dataTablesResults)) {
     #cdm source
-    t_cdmSource <- transpose(results$cdmSource)
+    t_cdmSource <- data.table::transpose(results$cdmSource)
     colnames(t_cdmSource) <- rownames(results$cdmSource)
     field <- colnames(results$cdmSource)
     t_cdmSource <- cbind(field, t_cdmSource)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The European Health Data and Evidence Network (EHDEN) project has multiple yearl
 
 Quality control of the mapping is clearly important and therefore a procedure has been developed called SME Inspection in which a certified SME performs a series of tests on the CDM and produces a report that is send to the EHDEN Team for review. The goal of the inspection report is to provide insight into the completeness, transparency and quality of the performed Extraction Transform, and Load (ETL) process and the readiness of the data partner to be onboarded in the EHDEN and OHDSI data networks and participate in research studies. If the SME that is performing the inspection was not involved in the ETL implementation we advise to use a two-stage inspection process. A first inspection report can be made to provide recommendations to the Data Partner on how to improve the ETL and processes, if necessary. Ideally, this includes a site visit of the SME after providing instructions on the content of the report. The Data Partner can share this draft report with EHDEN to obtain additional input. Once the improvements have been made the final report can be created by the SME and send to EHDEN for approval.  
 
-An example of an inspection report for the Synpuf database can be found here: TO BE ADDED.
+An example of an inspection report for the Synpuf database can be found here: [link](https://github.com/EHDEN/CdmInspection/blob/master/extras/SYNPUF-results.docx).
 
 The CdmInspection R Package is part of this SME Inspection procedure and performs the following checks on top of the required [Data Quality Dashboard](https://github.com/OHDSI/DataQualityDashboard) step:
 
@@ -83,7 +83,7 @@ CdmInspection is being developed in R Studio.
 
 ### Development status
 
-Under development by the EHDEN consortium do not use!
+Stable Release
 
 ## Acknowledgements
 - The European Health Data & Evidence Network has received funding from the Innovative Medicines Initiative 2 Joint Undertaking (JU) under grant agreement No 806968. The JU receives support from the European Union’s Horizon 2020 research 

--- a/extras/CodeToRun.R
+++ b/extras/CodeToRun.R
@@ -92,13 +92,12 @@ connectionDetails <- DatabaseConnector::createConnectionDetails(dbms = dbms,
                                                                 password = password,
                                                                 port = port)
 
-# Azure connection
-connectionDetails <- DatabaseConnector::createConnectionDetails(dbms = dbms,
-                                                                server = server,
-                                                                user = user,
-                                                                password = password,
-                                                                connectionString = connectionString )
-#conn <- DatabaseConnector::connect(dbms = dbms,connectionDetails = connectionDetails)
+# If connectionString is provided
+# connectionDetails <- DatabaseConnector::createConnectionDetails(dbms = dbms,
+#                                                                server = server,
+#                                                                user = user,
+#                                                                password = password,
+#                                                                connectionString = connectionString )
 
 # For Oracle: define a schema that can be used to emulate temp tables:
 oracleTempSchema <- NULL


### PR DESCRIPTION
I have prefixed external packages' functions with their namespace in the R folder of the package. I haven't done that for pre-installed R packages (base, utils). It helps to avoir conflicts with other packages but it's also useful to find where an external dependency is used. 
I have launched "CodeToRun.R" script to verify it works the same.