### PR TITLE
Remove pretty column names with SQL aliases

### DIFF
--- a/R/Helper.R
+++ b/R/Helper.R
@@ -113,17 +113,29 @@ my_source_value_count_section <- function (x, data, table_number, domain, kind,s
   }
 
   if (n>0) {
-    my_body_add_table(x, value = data$result, style = "EHDEN")
+    if (kind == 'unmapped') {
+      alignment <- c('r','l','r','r') # #,name,n,n
+    } else {
+      alignment <- c('r','l','r','r') # #,concept_id,n,n
+    }
+    x <- my_body_add_table(
+      x,
+      value = data$result,
+      alignment = alignment,
+      style = "EHDEN"
+    )
   }
 
   officer::body_add_par(x, paste0("Query executed in ", sprintf("%.2f", data$duration), " secs"))
 }
 
 my_unmapped_section <- function(x, data, table_number, domain, smallCellCount) {
+  names(data$result) <- c("#", "Source Value", "#Records", "#Subjects")
   my_source_value_count_section(x, data, table_number, domain, "unmapped", smallCellCount)
 }
 
 my_mapped_section <- function(x, data, table_number, domain, smallCellCount) {
+  names(data$result) <- c("#", "Concept Name", "#Records", "#Subjects")
   my_source_value_count_section(x, data, table_number, domain, "mapped", smallCellCount)
 }
 

--- a/inst/sql/sql_server/checks/concept_counts_by_vocabulary.sql
+++ b/inst/sql/sql_server/checks/concept_counts_by_vocabulary.sql
@@ -6,9 +6,9 @@
 select vocabulary.vocabulary_id                                  as id,
        vocabulary.vocabulary_name                                as name,
        vocabulary.vocabulary_version                             as version,
-       sum(case standard_concept when 'S' then 1 else 0 end)     as S,
-       sum(case standard_concept when 'C' then 1 else 0 end)     as C,
-       sum(case when standard_concept = '' OR standard_concept IS NULL  then 1 else 0 end) as "-"
+       sum(case standard_concept when 'S' then 1 else 0 end)     as n_standard_concepts,
+       sum(case standard_concept when 'C' then 1 else 0 end)     as n_classification_concepts,
+       sum(case when standard_concept = '' OR standard_concept IS NULL  then 1 else 0 end) as n_non_standard_concepts
 from @vocabDatabaseSchema.vocabulary
 left join @vocabDatabaseSchema.concept
     on concept.vocabulary_id = vocabulary.vocabulary_id

--- a/inst/sql/sql_server/checks/data_tables_count.sql
+++ b/inst/sql/sql_server/checks/data_tables_count.sql
@@ -1,43 +1,43 @@
 -- Clinical data table counts
 
-select 'person' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.person
+select 'person' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.person
 UNION
-select 'care_site' as tablename, count_big(*) as count, NULL as "person count" from @cdmDatabaseSchema.care_site
+select 'care_site' as tablename, count_big(*) as count, NULL as n_persons from @cdmDatabaseSchema.care_site
 UNION
-select 'condition_era' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.condition_era
+select 'condition_era' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.condition_era
 UNION
-select 'condition_occurrence' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.condition_occurrence
+select 'condition_occurrence' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.condition_occurrence
 UNION
-select 'drug_exposure' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.drug_exposure
+select 'drug_exposure' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.drug_exposure
 UNION
-select 'cost' as tablename, count_big(*) as count, NULL as "person count" from @cdmDatabaseSchema.cost
+select 'cost' as tablename, count_big(*) as count, NULL as n_persons from @cdmDatabaseSchema.cost
 UNION
-select 'death' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.death
+select 'death' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.death
 UNION
-select 'device_exposure' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.device_exposure
+select 'device_exposure' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.device_exposure
 UNION
-select 'dose_era' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.dose_era
+select 'dose_era' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.dose_era
 UNION
-select 'drug_era' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.drug_era
+select 'drug_era' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.drug_era
 UNION
-select 'location' as tablename, count_big(*) as count, NULL as "person count" from @cdmDatabaseSchema.location
+select 'location' as tablename, count_big(*) as count, NULL as n_persons from @cdmDatabaseSchema.location
 UNION
-select 'measurement' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.measurement
+select 'measurement' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.measurement
 UNION
-select 'note' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.note
+select 'note' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.note
 UNION
-select 'observation' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.observation
+select 'observation' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.observation
 UNION
-select 'observation_period' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.observation_period
+select 'observation_period' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.observation_period
 UNION
-select 'payer_plan_period' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.payer_plan_period
+select 'payer_plan_period' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.payer_plan_period
 UNION
-select 'procedure_occurrence' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.procedure_occurrence
+select 'procedure_occurrence' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.procedure_occurrence
 UNION
-select 'provider' as tablename, count_big(*) as count, NULL as "person count" from @cdmDatabaseSchema.provider
+select 'provider' as tablename, count_big(*) as count, NULL as n_persons from @cdmDatabaseSchema.provider
 UNION
-select 'specimen' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.specimen
+select 'specimen' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.specimen
 UNION
-select 'visit_detail' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.visit_detail
+select 'visit_detail' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.visit_detail
 UNION
-select 'visit_occurrence' as tablename, count_big(*) as count, count_big(distinct person_id) as "person count" from @cdmDatabaseSchema.visit_occurrence
+select 'visit_occurrence' as tablename, count_big(*) as count, count_big(distinct person_id) as n_persons from @cdmDatabaseSchema.visit_occurrence

--- a/inst/sql/sql_server/checks/mapped_conditions.sql
+++ b/inst/sql/sql_server/checks/mapped_conditions.sql
@@ -4,8 +4,8 @@ SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(condition_occurrence_id) DESC) AS ROW_NUM,
        Cr.concept_name as concept_name,
-       floor((count_big(condition_occurrence_id)+99)/100)*100 as #Records,
-       floor((count_big(distinct person_id)+99)/100)*100 as #Subjects
+       floor((count_big(condition_occurrence_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.condition_occurrence C
 JOIN @vocabDatabaseSchema.CONCEPT CR
 ON C.condition_concept_id = CR.CONCEPT_ID

--- a/inst/sql/sql_server/checks/mapped_devices.sql
+++ b/inst/sql/sql_server/checks/mapped_devices.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(device_exposure_id) DESC) AS ROW_NUM,
-       Cr.concept_name as "Concept Name",
-       floor((count_big(device_exposure_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       Cr.concept_name as concept_name,
+       floor((count_big(device_exposure_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.device_exposure C
 JOIN @vocabDatabaseSchema.CONCEPT CR
 ON C.device_concept_id = CR.CONCEPT_ID

--- a/inst/sql/sql_server/checks/mapped_drugs.sql
+++ b/inst/sql/sql_server/checks/mapped_drugs.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(drug_exposure_id) DESC) AS ROW_NUM,
-       Cr.concept_name as "Concept Name",
-       floor((count_big(drug_exposure_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       Cr.concept_name as concept_name,
+       floor((count_big(drug_exposure_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.drug_exposure C
 JOIN @vocabDatabaseSchema.CONCEPT CR
 ON C.drug_concept_id = CR.CONCEPT_ID

--- a/inst/sql/sql_server/checks/mapped_measurements.sql
+++ b/inst/sql/sql_server/checks/mapped_measurements.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(measurement_id) DESC) AS ROW_NUM,
-       Cr.concept_name as "Concept Name",
-       floor((count_big(measurement_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       Cr.concept_name as concept_name,
+       floor((count_big(measurement_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.measurement C
 JOIN @vocabDatabaseSchema.CONCEPT CR
 ON C.measurement_concept_id = CR.CONCEPT_ID

--- a/inst/sql/sql_server/checks/mapped_observations.sql
+++ b/inst/sql/sql_server/checks/mapped_observations.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(observation_id) DESC) AS ROW_NUM,
-       Cr.concept_name as "Concept Name",
-       floor((count_big(observation_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       Cr.concept_name as concept_name,
+       floor((count_big(observation_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.observation C
 JOIN @vocabDatabaseSchema.CONCEPT CR
 ON C.observation_concept_id = CR.CONCEPT_ID

--- a/inst/sql/sql_server/checks/mapped_procedures.sql
+++ b/inst/sql/sql_server/checks/mapped_procedures.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(procedure_occurrence_id) DESC) AS ROW_NUM,
-       Cr.concept_name as "Concept Name",
-       floor((count_big(procedure_occurrence_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       Cr.concept_name as concept_name,
+       floor((count_big(procedure_occurrence_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.procedure_occurrence C
 JOIN @vocabDatabaseSchema.CONCEPT CR
 ON C.procedure_concept_id = CR.CONCEPT_ID

--- a/inst/sql/sql_server/checks/mapped_visits.sql
+++ b/inst/sql/sql_server/checks/mapped_visits.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(*) DESC) AS ROW_NUM,
-       Cr.concept_name as "Concept Name",
-       floor((count_big(*)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       Cr.concept_name as concept_name,
+       floor((count_big(*)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.visit_occurrence C
   JOIN @vocabDatabaseSchema.CONCEPT CR
     ON C.visit_concept_id = CR.CONCEPT_ID

--- a/inst/sql/sql_server/checks/mapping_completeness.sql
+++ b/inst/sql/sql_server/checks/mapping_completeness.sql
@@ -1,173 +1,236 @@
---Query 2 Completeness of Mappings per Entity
-select 'condition' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
+select  'Condition' as domain,
+        count_big(source_value) as n_codes_source,
+        sum(is_mapped) as n_codes_mapped,
+        100.0*sum(is_mapped) / count_big(*) as p_codes_mapped,
+        sum(num_records) as n_records_source,
+        sum(case when is_mapped > 0 then num_records else 0 end) as n_records_mapped,
+        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as p_records_mapped
 from
 (
-select condition_source_value as source_value, case when condition_concept_id > 0 then 1 else 0 end as is_mapped, count_big(person_id) as num_records
+select condition_source_value, case when condition_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
 from @cdmDatabaseSchema.condition_occurrence
 group by condition_source_value, case when condition_concept_id > 0 then 1 else 0 end
-) t1
+) T
 
 union
 
-select 'procedure' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
+select 'Procedure', count_big(*),
+        sum(is_mapped),
+        100.0*sum(is_mapped) / count_big(*),
+        sum(num_records),
+        sum(case when is_mapped > 0 then num_records else 0 end),
+        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
 from
 (
-select procedure_source_value as source_value, case when procedure_concept_id > 0 then 1 else 0 end as is_mapped, count_big(person_id) as num_records
+select procedure_source_value, case when procedure_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
 from @cdmDatabaseSchema.procedure_occurrence
 group by procedure_source_value, case when procedure_concept_id > 0 then 1 else 0 end
-) t1
+) T
 
 union
 
-select 'device' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_recordss
+select 'Device', count_big(*),
+        sum(is_mapped),
+        100.0*sum(is_mapped) / count_big(*),
+        sum(num_records),
+        sum(case when is_mapped > 0 then num_records else 0 end),
+        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
 from
 (
-select device_source_value as source_value, case when device_concept_id > 0 then 1 else 0 end as is_mapped, count_big(person_id) as num_records
+select device_source_value, case when device_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
 from @cdmDatabaseSchema.device_exposure
 group by device_source_value, case when device_concept_id > 0 then 1 else 0 end
-) t1
+) T
 
 
 union
 
-select 'drug' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
+select 'Drug', count_big(*),
+        sum(is_mapped),
+        100.0*sum(is_mapped) / count_big(*),
+        sum(num_records),
+        sum(case when is_mapped > 0 then num_records else 0 end),
+        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
 from
 (
-select drug_source_value as source_value, case when drug_concept_id > 0 then 1 else 0 end as is_mapped, count_big(person_id) as num_records
+select drug_source_value, case when drug_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
 from @cdmDatabaseSchema.drug_exposure
 group by drug_source_value, case when drug_concept_id > 0 then 1 else 0 end
-) t1
+) T
 
 
 
 union
 
-select 'observation' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
+select 'Observation', count_big(*),
+        sum(is_mapped),
+        100.0*sum(is_mapped) / count_big(*),
+        sum(num_records),
+        sum(case when is_mapped > 0 then num_records else 0 end),
+        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
 from
 (
-select observation_source_value as source_value, case when observation_concept_id > 0 then 1 else 0 end as is_mapped, count_big(person_id) as num_records
+select observation_source_value, case when observation_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
 from @cdmDatabaseSchema.observation
 group by observation_source_value, case when observation_concept_id > 0 then 1 else 0 end
-) t1
+) T
 
 
 
 union
 
-select 'measurement' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
+select 'Measurement', count_big(*),
+        sum(is_mapped),
+        100.0*sum(is_mapped) / count_big(*),
+        sum(num_records),
+        sum(case when is_mapped > 0 then num_records else 0 end),
+        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
 from
 (
-select measurement_source_value as source_value, case when measurement_concept_id > 0 then 1 else 0 end as is_mapped, count_big(person_id) as num_records
+select measurement_source_value, case when measurement_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
 from @cdmDatabaseSchema.measurement
 group by measurement_source_value, case when measurement_concept_id > 0 then 1 else 0 end
-) t1
+) T
 
 union
 
-select 'visit_occurrence' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
+select 'Visit', count_big(*),
+        sum(is_mapped),
+        100.0*sum(is_mapped) / count_big(*),
+        sum(num_records),
+        sum(case when is_mapped > 0 then num_records else 0 end),
+        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
 from
 (
-select visit_source_value as source_value, case when visit_concept_id > 0 then 1 else 0 end as is_mapped, count_big(person_id) as num_records
+select visit_source_value, case when visit_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
 from @cdmDatabaseSchema.visit_occurrence
 group by visit_source_value, case when visit_concept_id > 0 then 1 else 0 end
-) t1
+) T
 
 union
 
- select 'measurement-unit' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
- from
- (
-     select unit_source_value as source_value, case when unit_concept_id > 0 then 1 else 0 end as is_mapped, count(person_id) as num_records
-     from @cdmDatabaseSchema.measurement
-     where unit_concept_id IS NOT NULL
-     group by unit_source_value, case when unit_concept_id > 0 then 1 else 0 end
- ) t1
+select 'Measurement unit', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select unit_source_value, case when unit_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.measurement
+   where unit_concept_id IS NOT NULL
+   group by unit_source_value, case when unit_concept_id > 0 then 1 else 0 end
+) T
 
- union
+union
 
- select 'observation-unit' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
- from
- (
-     select unit_source_value as source_value, case when unit_concept_id > 0 then 1 else 0 end as is_mapped, count(person_id) as num_records
-     from @cdmDatabaseSchema.observation
-     where unit_concept_id IS NOT NULL
-     group by unit_source_value, case when unit_concept_id > 0 then 1 else 0 end
- ) t1
+select 'Observation unit', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select unit_source_value, case when unit_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.observation
+   where unit_concept_id IS NOT NULL
+   group by unit_source_value, case when unit_concept_id > 0 then 1 else 0 end
+) T
 
- union
+union
 
- select 'measurement-value' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
- from
- (
-     select value_source_value as source_value, case when value_as_concept_id > 0 then 1 else 0 end as is_mapped, count(person_id) as num_records
-     from @cdmDatabaseSchema.measurement
-     where value_as_concept_id IS NOT NULL
-     group by value_source_value, case when value_as_concept_id > 0 then 1 else 0 end
- ) t1
+select 'Measurement value', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select value_source_value, case when value_as_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.measurement
+   where value_as_concept_id IS NOT NULL
+   group by value_source_value, case when value_as_concept_id > 0 then 1 else 0 end
+) T
 
- union
+union
 
- select 'observation-value' as domain, count_big(*) as num_source_concepts,
-        sum(is_mapped) as num_mapped_codes,
-        100.0*sum(is_mapped) / count_big(*) as pct_mapped_codes,
-        sum(num_records) as num_records,
-        sum(case when is_mapped > 0 then num_records else 0 end) as num_mapped_records,
-        100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records) as pct_mapped_records
- from
- (
-     select '' as source_value, case when value_as_concept_id > 0 then 1 else 0 end as is_mapped, count(person_id) as num_records
-     from @cdmDatabaseSchema.observation
-     where value_as_concept_id IS NOT NULL
-     group by case when value_as_concept_id > 0 then 1 else 0 end
- ) t1
+select 'Observation value', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select '', case when value_as_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.observation
+   where value_as_concept_id IS NOT NULL
+   group by case when value_as_concept_id > 0 then 1 else 0 end
+) T
 
+union
+
+select 'Provider Specialty', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select specialty_source_value, case when specialty_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.provider
+   where specialty_concept_id IS NOT NULL
+   group by specialty_source_value, case when specialty_concept_id > 0 then 1 else 0 end
+) T
+
+union
+
+select 'Specimen', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select specimen_source_value, case when specimen_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.specimen
+   where specimen_concept_id IS NOT NULL
+   group by specimen_source_value, case when specimen_concept_id > 0 then 1 else 0 end
+) T
+
+union
+
+select 'Death cause', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select cause_source_value, case when cause_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.death
+   where cause_concept_id IS NOT NULL
+   group by cause_source_value, case when cause_concept_id > 0 then 1 else 0 end
+) T
+
+union
+
+select 'Condition status', count_big(*),
+      sum(is_mapped),
+      100.0*sum(is_mapped) / count_big(*),
+      sum(num_records),
+      sum(case when is_mapped > 0 then num_records else 0 end),
+      100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
+from
+(
+   select condition_status_source_value, case when condition_status_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   from @cdmDatabaseSchema.condition_occurrence
+   where condition_status_concept_id IS NOT NULL
+   group by condition_status_source_value, case when condition_status_concept_id > 0 then 1 else 0 end
+) T

--- a/inst/sql/sql_server/checks/mapping_levels_drugs.sql
+++ b/inst/sql/sql_server/checks/mapping_levels_drugs.sql
@@ -1,9 +1,9 @@
 -- Levels at which drugs are mapped
 
-select concept_class_id as "Class",
-       count_big( drug_exposure_id) as "#Records",
-       count_big(distinct person_id) as "#Patients",
-       count_big(distinct drug_source_value) as "#Source Codes"
+select concept_class_id as class,
+       count_big(drug_exposure_id) as n_records,
+       count_big(distinct person_id) as n_patients,
+       count_big(distinct drug_source_value) as n_source_codes
 from @cdmDatabaseSchema.drug_exposure
 join @vocabDatabaseSchema.concept on drug_concept_id=concept_id
 where concept.domain_id = 'Drug'

--- a/inst/sql/sql_server/checks/unmapped_conditions.sql
+++ b/inst/sql/sql_server/checks/unmapped_conditions.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(condition_occurrence_id) DESC) AS ROW_NUM,
-       condition_source_value as "Source Value",
-       floor((count_big(condition_occurrence_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       condition_source_value as source_value,
+       floor((count_big(condition_occurrence_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.condition_occurrence where condition_concept_id = 0
 group by condition_source_value
 having count_big(condition_occurrence_id)>@smallCellCount

--- a/inst/sql/sql_server/checks/unmapped_devices.sql
+++ b/inst/sql/sql_server/checks/unmapped_devices.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(device_exposure_id) DESC) AS ROW_NUM,
-       device_source_value as "Source Value",
-       floor((count_big(device_exposure_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       device_source_value as source_value,
+       floor((count_big(device_exposure_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.device_exposure where device_concept_id = 0
 group by device_source_value
 having count_big(device_exposure_id)>@smallCellCount

--- a/inst/sql/sql_server/checks/unmapped_drugs.sql
+++ b/inst/sql/sql_server/checks/unmapped_drugs.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(drug_exposure_id) DESC) AS ROW_NUM,
-       drug_source_value as "Source Value",
-       floor((count_big(drug_exposure_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       drug_source_value as source_value,
+       floor((count_big(drug_exposure_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.drug_exposure where drug_concept_id = 0
 group by drug_source_value
 having count_big(drug_exposure_id)>@smallCellCount

--- a/inst/sql/sql_server/checks/unmapped_measurements.sql
+++ b/inst/sql/sql_server/checks/unmapped_measurements.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(measurement_id) DESC) AS ROW_NUM,
-       measurement_source_value as "Source Value",
-       floor((count_big(measurement_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       measurement_source_value as source_value,
+       floor((count_big(measurement_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.measurement where measurement_concept_id = 0
 group by measurement_source_value
 having count_big(measurement_id)>@smallCellCount

--- a/inst/sql/sql_server/checks/unmapped_observations.sql
+++ b/inst/sql/sql_server/checks/unmapped_observations.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(observation_id) DESC) AS ROW_NUM,
-       observation_source_value as "Source Value",
-       floor((count_big(observation_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       observation_source_value as source_value,
+       floor((count_big(observation_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.observation where observation_concept_id = 0
 group by observation_source_value
 having count_big(observation_id)>@smallCellCount

--- a/inst/sql/sql_server/checks/unmapped_procedures.sql
+++ b/inst/sql/sql_server/checks/unmapped_procedures.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(procedure_occurrence_id) DESC) AS ROW_NUM,
-       procedure_source_value as "Source Value",
-       floor((count_big(procedure_occurrence_id)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       procedure_source_value as source_value,
+       floor((count_big(procedure_occurrence_id)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
        from @cdmDatabaseSchema.procedure_occurrence where procedure_concept_id = 0
 group by procedure_source_value
 having count_big(procedure_occurrence_id)>@smallCellCount

--- a/inst/sql/sql_server/checks/unmapped_visits.sql
+++ b/inst/sql/sql_server/checks/unmapped_visits.sql
@@ -3,9 +3,9 @@
 SELECT *
 FROM (
 	select ROW_NUMBER() OVER(ORDER BY count_big(*) DESC) AS ROW_NUM,
-       visit_source_value as "Source Value",
-       floor((count_big(*)+99)/100)*100 as "#Records",
-       floor((count_big(distinct person_id)+99)/100)*100 as "#Subjects"
+       visit_source_value as source_value,
+       floor((count_big(*)+99)/100)*100 as n_records,
+       floor((count_big(distinct person_id)+99)/100)*100 as n_subjects
   from @cdmDatabaseSchema.visit_occurrence
   where visit_concept_id = 0
   group by visit_source_value


### PR DESCRIPTION
Fixes #85 and fixes #86. 

SQL aliases are not cross-platform compatible. All aliases should conform to the [HADES SQL conventions](https://ohdsi.github.io/Hades/codeStyle.html#OHDSI_code_style_for_SQL) and pretty column naming done in R.

- [x] Go through all sql documents, snake_case all column aliases and move pretty naming to R.