### PR TITLE
ITTM: Provide name for emtpy string column.

### DIFF
--- a/inst/sql/sql_server/checks/mapping_completeness.sql
+++ b/inst/sql/sql_server/checks/mapping_completeness.sql
@@ -165,7 +165,7 @@ select 'Observation value', count_big(*),
       100.0*sum(case when is_mapped > 0 then num_records else 0 end)/sum(num_records)
 from
 (
-   select '', case when value_as_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
+   select '' as empty_col_name, case when value_as_concept_id > 0 then 1 else 0 end as is_mapped, count_big(*) as num_records
    from @cdmDatabaseSchema.observation
    where value_as_concept_id IS NOT NULL
    group by case when value_as_concept_id > 0 then 1 else 0 end


### PR DESCRIPTION
ITTM: Query with no column name (retrieving empty string '') in mapping_completeness.sql gives error when running CDMInspection ("SQLServerException: No column name was specified for column 1 of 'T'."), as a solution we named this column and CDMInspection works fine.