### PR TITLE
Try print error message in the case that we can't connect to the webapi

### DIFF
--- a/R/CdmInspection.R
+++ b/R/CdmInspection.R
@@ -214,7 +214,9 @@ cdmInspection <- function (connectionDetails,
       ParallelLogger::logInfo(sprintf("> Connected successfully to %s", baseUrl))
       ParallelLogger::logInfo(sprintf("> WebAPI version: %s", webAPIversion))},
              error = function (e) {
+               errorMessage <- conditionMessage(e)
                ParallelLogger::logError(paste0("Could not connect to the WebAPI: ", baseUrl))
+               ParallelLogger::logError(paste0("Error details: ", errorMessage))
                webAPIversion <- "Failed"
       })
   }


### PR DESCRIPTION
Print underlying WebApi connection failure reason.

eg

```
>  Retrieving duration of Achilles queries in 0.15 secs
>  Retrieving duration of Achilles queries in 0.15 secs
Connecting using SQL Server driver
>  Executing vocabulary query benchmark in 3.65 secs
>  Executing vocabulary query benchmark in 3.65 secs
Running WebAPIChecks
Running WebAPIChecks
Could not connect to the WebAPI: http://host.docker.internal/WebAPI
Could not connect to the WebAPI: http://host.docker.internal/WebAPI
Error details: Could not reach WebApi. Possibly the base URL is not valid or is not reachable?
Please verify
- is it in the form http://server.org:80/WebAPI,
- are you are connected to the networkStatus code: 404
Error details: Could not reach WebApi. Possibly the base URL is not valid or is not reachable?
Please verify
- is it in the form http://server.org:80/WebAPI,
- are you are connected to the networkStatus code: 404
Done.
Done.
Complete CdmInspection took  0.25  minutes
Complete CdmInspection took  0.25  minutes
The cdm inspection results have been exported to: /report/MyDatabaseId
```